### PR TITLE
Permit headers with no "typ".

### DIFF
--- a/jwt.ml
+++ b/jwt.ml
@@ -56,7 +56,7 @@ let algorithm_of_string = function
 type header =
 {
   alg : algorithm ;
-  typ : string ; (* IMPROVEME: Need a sum type *)
+  typ : string option; (* IMPROVEME: Need a sum type *)
 }
 
 let header_of_algorithm_and_typ alg typ = { alg ; typ }
@@ -73,21 +73,17 @@ let typ_of_header h = h.typ
 
 let json_of_header header =
   `Assoc
-  [
-    ("alg", `String (string_of_algorithm (algorithm_of_header header))) ;
-    ("typ", `String (typ_of_header header))
-  ]
+    (("alg", `String (string_of_algorithm (algorithm_of_header header))) ::
+     (match typ_of_header header with
+      | Some typ -> [("typ", `String typ)]
+      | None -> []))
 
 let string_of_header header =
   let json = json_of_header header in Yojson.Basic.to_string json
 
 let header_of_json json =
   let alg = Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "alg" json) in
-  let typ =
-    match Yojson.Basic.Util.to_string_option (Yojson.Basic.Util.member "typ" json) with
-    | Some typ_ -> typ_
-    | None -> "JWT"
-  in
+  let typ = Yojson.Basic.Util.to_string_option (Yojson.Basic.Util.member "typ" json) in
   { alg = algorithm_of_string alg ; typ }
 
 let header_of_string str =

--- a/jwt.ml
+++ b/jwt.ml
@@ -83,7 +83,11 @@ let string_of_header header =
 
 let header_of_json json =
   let alg = Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "alg" json) in
-  let typ = Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "typ" json) in
+  let typ =
+    match Yojson.Basic.Util.to_string_option (Yojson.Basic.Util.member "typ" json) with
+    | Some typ_ -> typ_
+    | None -> "JWT"
+  in
   { alg = algorithm_of_string alg ; typ }
 
 let header_of_string str =

--- a/jwt.mli
+++ b/jwt.mli
@@ -57,7 +57,7 @@ type header
 
 val header_of_algorithm_and_typ :
   algorithm ->
-  string    ->
+  string option ->
   header
 
 (* ------- *)
@@ -66,7 +66,7 @@ val header_of_algorithm_and_typ :
 (* IMPROVEME: for the moment, only HS256 is supported. *)
 val algorithm_of_header : header -> algorithm
 
-val typ_of_header : header -> string
+val typ_of_header : header -> string option
 
 (* getters *)
 (* ------- *)


### PR DESCRIPTION
Default to "JWT".

From the [JWS Spec][1]

> This parameter is ignored by JWS implementations; any processing of this parameter is performed by the JWS application. Use of this Header Parameter is OPTIONAL.

[1]: https://tools.ietf.org/html/rfc7515#section-4.1.9