### PR TITLE
require base64 >= 2.0.0

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -17,7 +17,7 @@ install: [make "install"]
 remove: [make "remove"]
 
 depends: [
-  "base64"
+  "base64" {>= "2.0.0"}
   "yojson"
   "cryptokit"
   "re"


### PR DESCRIPTION
before `B64` was not the module name provided by the base64 library