### PR TITLE
Add support for RS256 (via nocrypto).

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,5 @@
 PKG base64
 PKG cryptokit
+PKG nocrypto
 PKG yojson
 PKG re.str

--- a/META
+++ b/META
@@ -1,4 +1,4 @@
-requires = "base64 cryptokit re.str yojson"
+requires = "base64 cryptokit nocrypto re.str yojson"
 version = "0.1"
 description = "Implementation of JSON Web Tokens in OCaml"
 archive(byte) = "jwt.cma"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CMA_FILE	= $(LIB_NAME).cma
 CMXA_FILE	= $(LIB_NAME).cmxa
 A_FILE		= $(LIB_NAME).a
 
-PACKAGES	= -package base64 -package yojson -package cryptokit -package re.str
+PACKAGES	= -package base64 -package yojson -package cryptokit -package nocrypto -package re.str
 
 all: build
 

--- a/jwt.mli
+++ b/jwt.mli
@@ -32,13 +32,10 @@ exception Bad_payload
 
 (* IMPROVEME: add other algorithm *)
 type algorithm =
+  | RS256 of Nocrypto.Rsa.priv
   | HS256 of string (* the argument is the secret key *)
   | HS512 of string (* the argument is the secret key *)
   | Unknown
-
-val fn_of_algorithm :
-  algorithm ->
-  Cryptokit.hash
 
 val string_of_algorithm :
   algorithm ->

--- a/opam/opam
+++ b/opam/opam
@@ -20,5 +20,6 @@ depends: [
   "base64"
   "yojson"
   "cryptokit"
+  "nocrypto"
   "re"
 ]


### PR DESCRIPTION
This adds support for the `RS256` alg, but adds a dependency on [`nocrypto`](https://github.com/mirleft/ocaml-nocrypto) (I couldn't find an easy to use `RSASSA-PKCS1-V1_5-SIGN` function in `cryptokit`).

This is obviously sub-optimal. A couple of options are:

* Switch entirely to `nocrypto`.
* Functorize on the crypto backend. Depending on which backend you choose (`cryptokit` or `nocrypto`), you get support for a different set of algorithms.

What do you think?