### PR TITLE
Remove yojson constraint and manually suppress deprecation warnings

### DIFF
--- a/jwt.opam
+++ b/jwt.opam
@@ -6,7 +6,7 @@ author: "Danny Willems <contact@danny-willems.be>"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base64" {= "3.0.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson"
   "cryptokit"
   "nocrypto"
   "re"

--- a/src/jwt.mli
+++ b/src/jwt.mli
@@ -80,11 +80,15 @@ val kid_of_header : header -> string option
 
 val string_of_header : header -> string
 
-val json_of_header : header -> Yojson.Basic.t
+[@@@warning "-3"]
+val json_of_header : header -> Yojson.Basic.json
+[@@@warning "+3"]
 
 val header_of_string : string -> header
 
-val header_of_json : Yojson.Basic.t -> header
+[@@@warning "-3"]
+val header_of_json : Yojson.Basic.json -> header
+[@@@warning "+3"]
 
 (* ----------- Header ---------- *)
 (* ----------------------------- *)
@@ -203,13 +207,17 @@ val string_of_payload :
   payload ->
   string
 
+[@@@warning "-3"]
 val payload_of_json :
-  Yojson.Basic.t ->
+  Yojson.Basic.json ->
   payload
+[@@@warning "+3"]
 
+[@@@warning "-3"]
 val json_of_payload :
   payload ->
-  Yojson.Basic.t
+  Yojson.Basic.json
+[@@@warning "+3"]
 
 (* ----------- Payload ---------- *)
 (* ------------------------------ *)
@@ -244,4 +252,6 @@ val t_of_token : string -> t
 (* ----------- JWT type ----------- *)
 (* -------------------------------- *)
 
-val verify : alg:string -> jwks:Yojson.Basic.t -> t -> bool
+[@@@warning "-3"]
+val verify : alg:string -> jwks:Yojson.Basic.json -> t -> bool
+[@@@warning "+3"]


### PR DESCRIPTION
The constraint on yojson was added recently, but it actually causes quite a few headaches as things like ppx_deriving_yojson are still on yojson < 1.6 (the version on opam anyway).

This relaxes the constraint and manually suppresses the deprecation warnings on Yojson.json - apparently in the dev version of yojson these deprecation warnings are removed anyway and Yojson.json is just aliased permenantly to Yojson.t (see discussion in https://github.com/ocaml-ppx/ppx_deriving_yojson/issues/94 for detail).

