### PR TITLE
Use nocrypto instead of cryptokit for all

### DIFF
--- a/jwt.opam
+++ b/jwt.opam
@@ -7,7 +7,6 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base64" {= "3.0.0"}
   "yojson"
-  "cryptokit"
   "nocrypto"
   "re"
 ]

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
  (name jwt)
  (public_name jwt)
  (modules jwt)
- (libraries base64 yojson cryptokit re.str nocrypto))
+ (libraries base64 yojson re.str nocrypto))

--- a/src/jwt.mli
+++ b/src/jwt.mli
@@ -33,8 +33,8 @@ exception Bad_payload
 (* IMPROVEME: add other algorithm *)
 type algorithm =
   | RS256 of Nocrypto.Rsa.priv option
-  | HS256 of string (* the argument is the secret key *)
-  | HS512 of string (* the argument is the secret key *)
+  | HS256 of Cstruct.t (* the argument is the secret key *)
+  | HS512 of Cstruct.t (* the argument is the secret key *)
   | Unknown
 
 val string_of_algorithm :


### PR DESCRIPTION
The tests seems to pass and I think this should be the same thing.

If I'm correct, the only public change here is that we changed the signature of HS256 and HS512 to have Cstruct.t as their value instead of strings.