### PR TITLE
Decode without paddin when base64url is used

### DIFF
--- a/src/jwt.ml
+++ b/src/jwt.ml
@@ -272,7 +272,7 @@ let b64_url_encode str =
   %s" str)
 
 let b64_url_decode str =
-  let r = Base64.decode ~alphabet:Base64.uri_safe_alphabet str in
+  let r = Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet str in
   match r with
   | Ok s -> s
   | Error _ -> failwith (Printf.sprintf "Something wrong happened while decoding


### PR DESCRIPTION
This matches the `b64_url_encode` function and makes the OIDC spec tester happy.